### PR TITLE
Fix mult_f boundary conventions, window grid, and mg time-domain path

### DIFF
--- a/WDMWaveletTransforms/inverse_wavelet_freq_funcs.py
+++ b/WDMWaveletTransforms/inverse_wavelet_freq_funcs.py
@@ -6,72 +6,6 @@ from numpy.typing import NDArray
 
 import WDMWaveletTransforms.fft_funcs as fft
 
-# @njit()
-# def unpack_wave_inverse(
-#    m: int,
-#    Nt: int,
-#    Nf: int,
-#    mult_f: int,
-#    phif: NDArray[np.floating],
-#    fft_prefactor2s: NDArray[np.complexfloating],
-#    res: NDArray[np.complexfloating],
-# ) -> None:
-#    """Helper for unpacking results of frequency domain inverse transform"""
-#    ND = Nf * Nt
-#    K = mult_f * Nt
-#
-#    assert 0 <= m <= Nf
-#    assert Nt % 2 == 0
-#    assert Nf % 2 == 0
-#
-#    assert Nf > 0
-#    assert Nt > 0
-#    assert mult_f > 0
-#
-#    f_size = int(ND//2 + 1)
-#    half_K = int(K //2)
-#    half_Nt = int(Nt // 2)
-#
-#    assert res.shape == (f_size,)
-#    assert fft_prefactor2s.shape == (K,)
-#    assert phif.shape == (half_K+1,)
-#
-#    i_midpoint = m * half_Nt
-#
-#    if m in (0, Nf):
-#        for i_ind in range(half_K):
-#            i = abs(i_midpoint - i_ind)
-#            ind3 = (2 * i) % K
-#            #for r in range(mult_f):
-#            res[i] += fft_prefactor2s[ind3] * phif[i_ind]
-#        if m == Nf:
-#            i_ind = half_K
-#            i = abs(i_midpoint - i_ind)
-#            ind3 = 0 * mult_f
-#            #for r in range(mult_f):
-#            res[i] += fft_prefactor2s[ind3] * phif[i_ind]
-#    else:
-#        ind31 = i_midpoint % K
-#        ind32 = i_midpoint % K
-#        for i_ind in range(half_K):
-#            i1 = i_midpoint - i_ind
-#            i2 = i_midpoint + i_ind
-#
-#            if i1 >= 0:
-#                #for r in range(mult_f):
-#                res[i1] += fft_prefactor2s[ind31] * phif[i_ind]
-#            if i2 < f_size:
-#                #for r in range(mult_f):
-#                res[i2] += fft_prefactor2s[ind32] * phif[i_ind]
-#            ind31 -= 1
-#            ind32 += 1
-#            if ind31 < 0:
-#                ind31 = K - 1
-#            if ind32 == K:
-#                ind32 = 0
-#        #for r in range(mult_f):
-#        res[i_midpoint] = fft_prefactor2s[(mult_f * i_midpoint) % K] * phif[0] #* np.sqrt(mult_f)
-
 
 @njit()
 def unpack_wave_inverse(
@@ -83,7 +17,18 @@ def unpack_wave_inverse(
     fft_prefactor2s: NDArray[np.complexfloating],
     res: NDArray[np.complexfloating],
 ) -> None:
-    """Helper for unpacking results of frequency domain inverse transform"""
+    """Helper for unpacking results of frequency domain inverse transform.
+
+    fft_prefactor2s is the length-Nt fft of the packed pixel coefficients; window
+    tap delta contributes fft_prefactor2s[jj mod Nt] * phif[|delta|] at spectrum
+    bin jj = m*Nt/2 + delta, over the open support delta in (-K/2, K/2).
+
+    For interior bands, contributions at bins outside the rfft range [0, ND/2]
+    are the mirror lobe of the real wavelet and fold back conjugated; the
+    self-conjugate bins 0 and ND/2 receive both lobes at once (2 Re).  The
+    self-conjugate bands m = 0 and m = Nf scatter only their own half-plane,
+    which is already the complete synthesis for reflection-symmetric atoms.
+    """
     ND = Nf * Nt
     K = mult_f * Nt
 
@@ -93,75 +38,50 @@ def unpack_wave_inverse(
 
     assert Nf > 0
     assert Nt > 0
-    assert mult_f > 0
+    assert 0 < mult_f <= Nf
 
     f_size = int(ND // 2 + 1)
     half_K = int(K // 2)
     half_Nt = int(Nt // 2)
+    half_ND = int(ND // 2)
 
     assert res.shape == (f_size,)
-    assert fft_prefactor2s.shape == (K,)
+    assert fft_prefactor2s.shape == (Nt,)
     assert phif.shape == (half_K + 1,)
 
     i_midpoint = m * half_Nt
 
     if m in (0, Nf):
+        # taps at delta = 0..K/2-1 for m = 0, delta = 1-K/2..0 for m = Nf; both
+        # stay inside [0, ND/2] since mult_f <= Nf
         for i_ind in range(half_K):
             i = abs(i_midpoint - i_ind)
-            ind3 = (2 * i) % K
-            # for r in range(mult_f):
-            res[i] += fft_prefactor2s[ind3] * phif[i_ind]
-        if m == Nf:
-            i_ind = half_K
-            i = abs(i_midpoint - i_ind)
-            ind3 = 0 * mult_f
-            # for r in range(mult_f):
+            ind3 = (2 * i) % Nt
             res[i] += fft_prefactor2s[ind3] * phif[i_ind]
     else:
-        ind31 = (i_midpoint - 1) % K
         for i_ind in range(1, half_K):
             i1 = i_midpoint - i_ind
+            val = fft_prefactor2s[i1 % Nt] * phif[i_ind]
+            if i1 > 0:
+                res[i1] += val
+            elif i1 == 0:
+                # self-conjugate bin: both lobes land here
+                res[0] += 2.0 * val.real
+            else:
+                # mirror lobe of the real atom folds back conjugated
+                res[-i1] += np.conj(val)
 
-            if i1 >= 0:  # and i1%half_Nt >0:
-                # for r in range(mult_f):
-                res[i1] += fft_prefactor2s[ind31] * phif[i_ind]
-            ind31 -= 1
-            if ind31 < 0:
-                ind31 = K - 1
-
-        ind32 = (i_midpoint + 1) % K
-        for i_ind in range(1, half_K):
             i2 = i_midpoint + i_ind
-            if i2 < f_size:  # and i2%half_Nt >0:
-                # for r in range(mult_f):
-                res[i2] += fft_prefactor2s[ind32] * phif[i_ind]
-            ind32 += 1
-            if ind32 == K:
-                ind32 = 0
-        # for r in range(mult_f):
-        # TODO why is only this one conjugated? maybe some other indices should be but the effect is smaller?
-        if mult_f % 2 or m % 2 == 0:
-            res[i_midpoint] += fft_prefactor2s[(mult_f * i_midpoint) % K] * phif[0]  # * np.sqrt(mult_f)
-        else:
-            res[i_midpoint] += -np.conjugate(fft_prefactor2s[(mult_f * i_midpoint) % K]) * phif[0]  # * np.sqrt(mult_f)
+            val = fft_prefactor2s[i2 % Nt] * phif[i_ind]
+            if i2 < half_ND:
+                res[i2] += val
+            elif i2 == half_ND:
+                res[half_ND] += 2.0 * val.real
+            else:
+                res[ND - i2] += np.conj(val)
 
-
-# @njit()
-# def unpack_wave_inverse(m, Nt, Nf, phif, fft_prefactor2s, res):
-#    """helper for unpacking results of frequency domain inverse transform"""
-#    ND = Nt*Nf
-#    i_min2 = min(max(Nt//2*(m-1), 0), ND//2+1)
-#    i_max2 = min(max(Nt//2*(m+1), 0), ND//2+1)
-#    for i in range(i_min2, i_max2):
-#        i_ind = np.abs(i-Nt//2*m)
-#        if i_ind > Nt//2:
-#            continue
-#        if m == 0:
-#            res[i] += fft_prefactor2s[(2*i) % Nt]*phif[i_ind]
-#        elif m == Nf:
-#            res[i] += fft_prefactor2s[(2*i) % Nt]*phif[i_ind]
-#        else:
-#            res[i] += fft_prefactor2s[i % Nt]*phif[i_ind]
+        # center tap; i_midpoint is strictly inside (0, ND/2) for interior m
+        res[i_midpoint] += fft_prefactor2s[i_midpoint % Nt] * phif[0]
 
 
 @njit()
@@ -169,17 +89,16 @@ def pack_wave_inverse(
     m: int,
     Nt: int,
     Nf: int,
-    mult_f: int,
     prefactor2s: NDArray[np.complexfloating],
     wave_in: NDArray[np.floating],
 ) -> None:
     """Helper for fast frequency domain inverse transform to prepare for fourier transform"""
     if m == 0:
         for n in range(Nt):
-            prefactor2s[n * mult_f] = 1 / np.sqrt(2) * wave_in[(2 * n) % Nt, 0]
+            prefactor2s[n] = 1 / np.sqrt(2) * wave_in[(2 * n) % Nt, 0]
     elif m == Nf:
         for n in range(Nt):
-            prefactor2s[n * mult_f] = 1 / np.sqrt(2) * wave_in[(2 * n) % Nt + 1, 0]
+            prefactor2s[n] = 1 / np.sqrt(2) * wave_in[(2 * n) % Nt + 1, 0]
     else:
         for n in range(Nt):
             val = float(wave_in[n, m])
@@ -188,10 +107,9 @@ def pack_wave_inverse(
             else:
                 mult2 = 1
 
-            prefactor2s[n * mult_f] = mult2 * val
+            prefactor2s[n] = mult2 * val
 
 
-# @njit()
 def inverse_wavelet_freq_helper_fast(
     wave_in: NDArray[np.floating],
     phif: NDArray[np.floating],
@@ -202,16 +120,11 @@ def inverse_wavelet_freq_helper_fast(
     """Jit compatible loop for inverse_wavelet_freq"""
     ND = Nf * Nt
 
-    prefactor2s = np.zeros(Nt * mult_f, dtype=complex)
+    prefactor2s = np.zeros(Nt, dtype=complex)
     res = np.zeros(ND // 2 + 1, dtype=complex)
 
-    phif_alt = phif[: Nt // 2 + 1]
-    prefactor2s_alt = np.zeros(Nt, dtype=complex)
-    res_alt = np.zeros(ND // 2 + 1, dtype=complex)
-
     for m in range(Nf + 1):
-        prefactor2s[:] = 0.0
-        pack_wave_inverse(m, Nt, Nf, mult_f, prefactor2s, wave_in)
+        pack_wave_inverse(m, Nt, Nf, prefactor2s, wave_in)
         fft_prefactor2s = fft.fft(prefactor2s)
         unpack_wave_inverse(m, Nt, Nf, mult_f, phif, fft_prefactor2s, res)
 

--- a/WDMWaveletTransforms/modified_gaussian.py
+++ b/WDMWaveletTransforms/modified_gaussian.py
@@ -3,9 +3,6 @@ import scipy.special
 from numba import njit
 from numpy.typing import NDArray
 from scipy.fft import fftn, ifftn, next_fast_len
-from scipy.signal import fftconvolve
-
-import WDMWaveletTransforms.fft_funcs as fft
 
 # ============================================================
 # Gaussian and atoms
@@ -15,26 +12,6 @@ import WDMWaveletTransforms.fft_funcs as fft
 @njit()
 def g_nu(x, nu: float):
     return np.sqrt(np.sqrt(2 * nu)) * np.exp(-np.pi * nu * x**2)
-
-
-@njit()
-def zak_g(t, s, nu: float, L: int = 20):
-    z = np.zeros_like(s, dtype=np.complex128)
-    for k in range(-L, L + 1):
-        z += g_nu(t + k, nu) * np.exp(2j * np.pi * k * s)
-    return z
-
-
-@njit()
-def zak_g_2filter(t, s, nu: float, L: int = 20):
-    z0 = np.zeros_like(s, dtype=np.complex128)
-    z1 = np.zeros_like(s, dtype=np.complex128)
-    for k in range(-L, L + 1):
-        prod0 = g_nu(t + k, nu) * np.exp(2j * np.pi * k * s)
-        prod1 = ((-1) ** (k)) * prod0
-        z0 += prod0
-        z1 += prod1
-    return (z0, z1)
 
 
 @njit()
@@ -91,69 +68,6 @@ def zak_g_abs2_fft(nu: float, Nt: int = 100, Ns: int = 100, L: int = 20) -> tupl
     return f.min(), f.max()
 
 
-@njit()
-def frame_bounds(nu: float, Nt: int = 100, Ns: int = 100, L: int = 20):
-    # ts = np.linspace(0, 1, Nt+1)[:Nt]
-    ss = np.linspace(0, 1, Ns + 1)[:Ns]
-
-    A = np.inf
-    B = -np.inf
-
-    t_min = -np.inf
-    s_min = -np.inf
-    t_max = -np.inf
-    s_max = -np.inf
-
-    for itrt in range(Nt):
-        t = itrt / Nt
-
-        # Z0 = zak_g(t, ss, nu, L=L)
-        # Z1 = zak_g(t, ss+0.5, nu, L=L)
-        # F = np.abs(Z0)**2 + np.abs(Z1)**2
-
-        Z0, Z1 = zak_g_2filter(t, ss, nu, L=L)
-        F = np.abs(Z0) ** 2 + np.abs(Z1) ** 2
-
-        # Z = zak_g(t, np.array([ss, ss+0.5]), nu, L=L)
-        # Z0 = Z[0]
-        # Z1 = Z[1]
-        # F = np.abs(Z0)**2 + np.abs(Z1)**2
-
-        # F = zak_g_abs(t, ss, nu, L=L)
-
-        j_min = np.argmin(F)
-        j_max = np.argmax(F)
-        f_min = F[j_min]
-        f_max = F[j_max]
-
-        # f_min, f_max, j_min, j_max = zak_g_abs2(t, Ns, nu, L=L)
-
-        if f_min < A:
-            A = f_min
-            t_min = t
-            # s_min = ss[j_min]
-            s_min = j_min / Ns
-
-        if f_max > B:
-            B = f_max
-            t_max = t
-            # s_max = ss[j_max]
-            s_max = j_max / Ns
-
-    # print("A_nu =", A)
-    # print("  attained near t =", t_min)
-    # print("  attained near s =", s_min)
-
-    # print("B_nu =", B)
-    # print("  attained near t =", t_max)
-    # print("  attained near s =", s_max)
-
-    # print("(B_nu - A_nu)/(B_nu + A_nu) =", (B - A) / (B + A))
-
-    return A, B, t_min, s_min, t_max, s_max
-
-
-# @njit()
 def frame_bounds_short(nu: float, Nt: int = 100, Ns: int = 100, L: int = 20, fft_mode: int = 0) -> tuple[float, float]:
     if fft_mode == 0:
         return zak_g_abs2(nu, Nt=Nt, Ns=Ns, L=L)
@@ -161,84 +75,6 @@ def frame_bounds_short(nu: float, Nt: int = 100, Ns: int = 100, L: int = 20, fft
         return zak_g_abs2_fft(nu, Nt=Nt, Ns=Ns, L=L)
     msg = 'fft_mode must be 0 or 1'
     raise ValueError(msg)
-
-
-@njit()
-def _omega_array_loop(M: int, N: int, nu: float) -> NDArray[np.complex128]:
-    n_pair = (2 * M + 1) * (2 * N + 1)
-    Omega = np.zeros((n_pair, n_pair), dtype=np.complex128)
-    itrp1 = 0
-    n_scales = np.zeros(2 * N + 1)
-    m_scales = np.zeros(2 * M + 1)
-    # calculate the scaling parts for difference in m and n
-    for dn in range(2 * N + 1):
-        n_scales[dn] = np.exp(-np.pi * nu * dn**2 / 2)
-    for dm in range(2 * M + 1):
-        m_scales[dm] = np.exp(-np.pi * dm**2 / (8 * nu))
-
-    # moduli = np.outer(n_scales, m_scales)
-
-    for m1 in range(-M, M + 1):
-        for n1 in range(-N, N + 1):
-            itrp2 = 0
-            for m2 in range(-M, M + 1):
-                dm = abs(m1 - m2)
-                for n2 in range(-N, N + 1):
-                    dn = abs(n1 - n2)
-                    if itrp2 >= itrp1:
-                        # real_part_arg = - np.pi * nu * (n1 - n2)**2 / 2 - np.pi * (m1 - m2)**2 / (8 * nu)
-                        # modulus = np.exp(real_part_arg)
-                        modulus = n_scales[dn] * m_scales[dm]
-                        # modulus = moduli[abs(n1-n2), abs(m1-m2)]
-                        # get the complex part of the array
-                        imag_part_arg = 1j ** np.mod(dm * (n1 + n2), 4)
-                        Omega[itrp1, itrp2] = modulus * imag_part_arg
-                        if itrp2 > itrp1:
-                            # take advantage of the fact the array is hermitian
-                            Omega[itrp2, itrp1] = modulus * np.conjugate(imag_part_arg)
-                    itrp2 += 1
-            itrp1 += 1
-    return Omega
-
-
-def _omega_array_loop_wrapper(M: int, N: int, nu: float) -> NDArray[np.complex128]:
-    return _omega_array_loop(M, N, nu)
-
-
-@njit()
-def _om_dot_helper_old(
-    M: int, N: int, b, m_scales: NDArray[np.float64], n_scales: NDArray[np.float64]
-) -> NDArray[np.complex128]:
-    n_pair = (2 * M + 1) * (2 * N + 1)
-    res = np.zeros(n_pair, dtype=np.complex128)
-
-    itrp1 = 0
-    for m1 in range(-M, M + 1):
-        for n1 in range(-N, N + 1):
-            itrp2 = 0
-            for m2 in range(-M, M + 1):
-                dm = abs(m1 - m2)
-                if m_scales[dm] == 0.0:
-                    # short circuit cases where the scaling is zero
-                    itrp2 += 2 * N + 1
-                    continue
-                for n2 in range(-N, N + 1):
-                    dn = abs(n1 - n2)
-                    if n_scales[dn] == 0.0:
-                        # short circuit cases where the scaling is zero
-                        pass
-                    elif itrp2 >= itrp1:
-                        modulus = n_scales[dn] * m_scales[dm]
-                        imag_part_arg = 1j ** np.mod(dm * (n1 + n2), 4)
-                        res[itrp1] += modulus * imag_part_arg * b[itrp2]
-                        if itrp2 > itrp1:
-                            # take advantage of the fact the array is hermitian
-                            res[itrp2] += modulus * np.conjugate(imag_part_arg) * b[itrp1]
-
-                        # assert_allclose(modulus, np.abs(Omega[itrp1, itrp2]), atol=1.e-100, rtol=1.e-14)
-                    itrp2 += 1
-            itrp1 += 1
-    return res
 
 
 def _next_fast_even(n: int) -> int:
@@ -268,21 +104,6 @@ def _om_dot_helper(
 
     convolved = ifftn(F_selected, fft_shape)
     Y = convolved[crop_m : crop_m + 2 * M + 1, crop_n : crop_n + 2 * N + 1]
-
-    return Y.reshape(-1)
-
-
-def _om_dot_helper_convolve(M: int, N: int, b, kernel_even, kernel_odd) -> NDArray[np.complex128]:
-    B = b.reshape(2 * M + 1, 2 * N + 1)
-
-    Y_even = fftconvolve(B, kernel_even, mode='same')
-    Y_odd = fftconvolve(B, kernel_odd, mode='same')
-
-    Y = Y_even.copy()
-    if N % 2 == 0:
-        Y[:, 1::2] = Y_odd[:, 1::2]
-    else:
-        Y[:, ::2] = Y_odd[:, ::2]
 
     return Y.reshape(-1)
 
@@ -340,9 +161,7 @@ def _kernel_helper(M: int, N: int, nu: float):
     return kernel_even, kernel_odd, m_scales, n_scales
 
 
-# @njit()
 def _recursive_loop(
-    Omega,
     Kmax: int,
     center_index: int,
     alpha: float,
@@ -357,7 +176,7 @@ def _recursive_loop(
     # Coefficient recursion from equations (6.2)--(6.3)
     # ============================================================
     assert compensate_mode in (0, 1)
-    assert fft_mode in (0, 1, 2, 3)
+    assert fft_mode in (0, 2), 'fft_mode must be 0 (fft) or 2 (explicit loop)'
     assert null_mode in (0, 1, 2)
     n_pair = (2 * M + 1) * (2 * N + 1)
 
@@ -377,27 +196,19 @@ def _recursive_loop(
     F_even = fftn(kernel_even, fft_shape)
     F_odd = np.roll(F_even, fft_shape[0] // 2, axis=0)
 
+    def om_dot(vec):
+        # apply the overlap matrix Omega, equivalent to np.dot(Omega, vec)
+        if fft_mode == 0:
+            return _om_dot_helper(M, N, vec, F_even, F_odd, fft_shape)
+        return _om_dot_helper_explicit(M, N, vec, kernel_even)
+
     c_k = 1.0
-    # Omega = _omega_array_loop_wrapper(M, N, nu)
-    # eig_omega = np.linalg.eigh(Omega)
 
     if null_mode in (0, 1):
         # get the component of b pointing into a (nearly) null eigenspace so that we can remove it from the actual iterative accumulation
         for k in range(Kmax + 1):
             # Equivalent to applying [I - 2P/(A+B)]
-            # mat_prod_alt = np.dot(Omega, b)
-            if fft_mode == 0:
-                mat_prod = _om_dot_helper(M, N, b_null, F_even, F_odd, fft_shape)
-            elif fft_mode == 1:
-                mat_prod = _om_dot_helper_convolve(M, N, b_null, kernel_even, kernel_odd)
-            elif fft_mode == 2:
-                mat_prod = _om_dot_helper_explicit(M, N, b_null, kernel_even)
-            elif fft_mode == 3:
-                mat_prod = _om_dot_helper_old(M, N, b_null, m_scales, n_scales)
-            else:
-                msg = 'Unrecogized option for fft_mode'
-                raise ValueError(msg)
-            b_null = b_null - alpha * mat_prod
+            b_null = b_null - alpha * om_dot(b_null)
 
         # remove the component of b in the nearly null eigenspace
         if null_mode == 0:
@@ -416,32 +227,16 @@ def _recursive_loop(
     for k in range(Kmax + 1):
         if compensate_mode == 0:
             a += c_k * (b - b_null)
-        elif compensate_mode == 1:
+        else:
             # accumulate a by Kahan compensated summation algorithm to reduce loss of numerical precision
             term = c_k * (b - b_null)
-            # term = c_k * b
             y = term - comp
             t = a + y
             comp = (t - a) - y
             a = t
-        else:
-            msg = 'Unrecognized option for compensate_mode'
-            raise ValueError(msg)
 
         # Equivalent to applying [I - 2P/(A+B)]
-        # mat_prod_alt = np.dot(Omega, b)
-        if fft_mode == 0:
-            mat_prod = _om_dot_helper(M, N, b, F_even, F_odd, fft_shape)
-        elif fft_mode == 1:
-            mat_prod = _om_dot_helper_convolve(M, N, b, kernel_even, kernel_odd)
-        elif fft_mode == 2:
-            mat_prod = _om_dot_helper_explicit(M, N, b, kernel_even)
-        elif fft_mode == 3:
-            mat_prod = _om_dot_helper_old(M, N, b, m_scales, n_scales)
-        else:
-            msg = 'Unrecogized option for fft_mode'
-            raise ValueError(msg)
-        b = b - alpha * mat_prod
+        b = b - alpha * om_dot(b)
         # c_k *= (2 * k + 1) / (2 * k + 2)
         # use exact form of c_k to try to reduce accumulated numerical error
         c_k = scipy.special.beta(1.5 + k, 0.5) / np.pi
@@ -449,7 +244,6 @@ def _recursive_loop(
 
 
 def _recursive_loop_wrapper(
-    Omega,
     Kmax: int,
     center_index: int,
     alpha: float,
@@ -461,7 +255,6 @@ def _recursive_loop_wrapper(
     null_mode: int,
 ):
     return _recursive_loop(
-        Omega,
         Kmax,
         center_index,
         alpha,
@@ -494,28 +287,11 @@ def _coefficient_recursion_helper(
 
     alpha = 2.0 / (A_nu + B_nu)
 
-    # ============================================================
-    # Index lattice
-    # ============================================================
     prefactor = 2.0 * np.sqrt(1.0 / (A_nu + B_nu))
-
-    n_pair = (2 * M + 1) * (2 * N + 1)
 
     center_index = M * (2 * N + 1) + N
 
-    # ============================================================
-    # Overlap matrix
-    # ============================================================
-    Omega = 0.0
-    # Omega = np.exp(
-    #    1j * np.pi * (m.T - m) * (n + n.T) / 2
-    #    - np.pi * nu * (n - n.T)**2 / 2
-    #    - np.pi * (m - m.T)**2 / (8 * nu)
-    # )
-    # assert_allclose(Omega, Omega_alt, atol=1.e-100, rtol=1.e-13)
-
     a = _recursive_loop_wrapper(
-        Omega,
         Kmax,
         center_index,
         alpha,
@@ -530,14 +306,6 @@ def _coefficient_recursion_helper(
     return a, prefactor
 
 
-# nu_init = 0.5
-# M_init = 20
-# N_init = 80
-# L_init = 20
-# Ns_init = 200
-# Nt_init = 200
-# Kmax_init = 240
-
 nu_init = 0.5
 M_init = 20
 N_init = 80
@@ -548,21 +316,43 @@ Kmax_init = 50
 fft_mode_frame_init = 0
 fft_mode_recurse_init = 2
 compensate_mode_init = 1
-a, prefactor = _coefficient_recursion_helper(
-    Kmax=Kmax_init,
-    M=M_init,
-    N=N_init,
-    nu=nu_init,
-    L=L_init,
-    Ns=Ns_init,
-    Nt=Nt_init,
-    fft_mode_frame=fft_mode_frame_init,
-    fft_mode_recurse=fft_mode_recurse_init,
-    compensate_mode=compensate_mode_init,
-)
 
-a_init = a.reshape(((2 * M_init + 1), (2 * N_init + 1)))
-# a_init = None
+# lazy cache for the dual-window expansion coefficients: computing them runs the
+# full coefficient recursion, so it is done on first use instead of at import
+_MG_EXPANSION_CACHE: dict = {}
+
+
+def get_mg_expansion(
+    Kmax: int = Kmax_init,
+    M: int = M_init,
+    N: int = N_init,
+    nu: float = nu_init,
+    L: int = L_init,
+    Ns: int = Ns_init,
+    Nt_frame: int = Nt_init,
+    fft_mode_frame: int = fft_mode_frame_init,
+    fft_mode_recurse: int = fft_mode_recurse_init,
+    compensate_mode: int = compensate_mode_init,
+    null_mode: int = 0,
+) -> tuple[NDArray[np.complex128], float]:
+    """Get the (2M+1, 2N+1) expansion coefficients a_mn and overall prefactor, cached."""
+    key = (Kmax, M, N, nu, L, Ns, Nt_frame, fft_mode_frame, fft_mode_recurse, compensate_mode, null_mode)
+    if key not in _MG_EXPANSION_CACHE:
+        a_flat, prefactor = _coefficient_recursion_helper(
+            Kmax=Kmax,
+            M=M,
+            N=N,
+            nu=nu,
+            L=L,
+            Ns=Ns,
+            Nt=Nt_frame,
+            fft_mode_frame=fft_mode_frame,
+            fft_mode_recurse=fft_mode_recurse,
+            compensate_mode=compensate_mode,
+            null_mode=null_mode,
+        )
+        _MG_EXPANSION_CACHE[key] = (a_flat.reshape(((2 * M + 1), (2 * N + 1))), prefactor)
+    return _MG_EXPANSION_CACHE[key]
 
 
 # ============================================================
@@ -576,24 +366,27 @@ def g_mn_x(x: NDArray[np.float64], m: int, n: int, nu: float) -> NDArray[np.comp
 
 
 @njit()
-def phi_vec(
-    Nf: int, mult_t: int, M: int = M_init, N: int = N_init, nu: float = nu_init, a_in=a_init
+def _phi_vec_core(
+    Nf: int, mult_t: int, M: int, N: int, nu: float, a_in: NDArray[np.complex128], prefactor: float
 ) -> NDArray[np.float64]:
-    assert mult_t % 2 == 0
     assert Nf % 2 == 0
     assert a_in.shape == (2 * M + 1, 2 * N + 1)
     K = mult_t * 2 * Nf
     ts = np.arange(-K // 2, K // 2) / Nf
     out = np.zeros(K, dtype=np.complex128)
 
-    itrp = 0
     for m in range(-M, M + 1):
         for n in range(-N, N + 1):
             coeff = a_in[m + M, n + N]
-            out += coeff * g_mn_x(ts, m, n, nu_init)
-            itrp += 1
+            out += coeff * g_mn_x(ts, m, n, nu)
 
     return prefactor * np.sqrt(2.0 / Nf) * np.real(out)
+
+
+def phi_vec(Nf: int, mult_t: int, M: int = M_init, N: int = N_init, nu: float = nu_init) -> NDArray[np.float64]:
+    """Time-domain window on the grid of K = 2*mult_t*Nf samples around the pixel center."""
+    a_in, prefactor = get_mg_expansion(M=M, N=N, nu=nu)
+    return _phi_vec_core(Nf, mult_t, M, N, nu, a_in, prefactor)
 
 
 @njit()
@@ -603,85 +396,66 @@ def g_mn_hat(y: NDArray[np.float64], m: int, n: int, nu: float) -> NDArray[np.co
 
 
 @njit()
-def phihat_eval(yvals: NDArray[np.float64], M: int = M_init, N: int = N_init, nu: float = nu_init, a_in=a_init):
+def _phihat_eval_core(
+    yvals: NDArray[np.float64], M: int, N: int, nu: float, a_in: NDArray[np.complex128], prefactor: float
+) -> NDArray[np.float64]:
     assert a_in.shape == (2 * M + 1, 2 * N + 1)
 
-    yvals = np.asarray(yvals)
     out = np.zeros_like(yvals, dtype=np.complex128)
 
-    itrp = 0
     for m in range(-M, M + 1):
         for n in range(-N, N + 1):
             coeff = a_in[m + M, n + N]
-            out += coeff * g_mn_hat(yvals, m, n, nu_init)
-            itrp += 1
+            out += coeff * g_mn_hat(yvals, m, n, nu)
 
     return prefactor * np.real(out)
 
 
-def phi_vec_transform(
-    Nf: int, mult_t: int = 16, M: int = M_init, N: int = N_init, nu: float = nu_init, a_in=a_init
-) -> NDArray[np.floating]:
-    """Get time domain phi as fourier transform of phitilde_vec"""
-    # TODO fix mult
-
-    OM: float = np.pi
-    DOM = float(OM / Nf)
-    insDOM: float = float(1.0 / np.sqrt(DOM))
-    K: int = int(mult_t * 2 * Nf)
-    half_K: int = int(mult_t * Nf)  # np.int64(K/2)
-
-    dom: float = 2 * np.pi / K  # max frequency is K/2*dom = pi/dt = OM
-
-    phitilde_loc = np.zeros(K, dtype=complex)
-
-    # zero frequency
-    phitilde_loc[0] = phihat_eval(0.0, M=M, N=N, nu=nu, a_in=a_in)
-
-    # postive frequencies
-    phitilde_loc[1 : half_K + 1] = phihat_eval(np.arange(1, half_K + 1) / half_K * Nf / 2, M=M, N=N, nu=nu, a_in=a_in)
-    # negative frequencies
-    phitilde_loc[half_K + 1 :] = phihat_eval(
-        -np.arange(half_K - 1, 0, -1) / half_K * Nf / 2, M=M, N=N, nu=nu, a_in=a_in
-    )
-    phi_loc = K * fft.ifft(phitilde_loc, K)
-
-    del phitilde_loc
-
-    phi = np.zeros(K, dtype=float)
-    phi[0:half_K] = np.real(phi_loc[half_K:K])
-    phi[half_K:] = np.real(phi_loc[0:half_K])
-
-    nrm: float = float(np.sqrt(K / dom))  # *np.linalg.norm(phi)
-
-    fac: float = float(float(np.sqrt(2.0)) / nrm)
-    return phi / np.sqrt(2.0 / Nf) / np.sqrt(np.pi) * fac
+def phihat_eval(
+    yvals: NDArray[np.float64], M: int = M_init, N: int = N_init, nu: float = nu_init
+) -> NDArray[np.float64]:
+    """Frequency-domain window; y in units of the band spacing 1/(2 dt Nf), band edge at y = 1/2."""
+    a_in, prefactor = get_mg_expansion(M=M, N=N, nu=nu)
+    return _phihat_eval_core(np.asarray(yvals, dtype=np.float64), M, N, nu, a_in, prefactor)
 
 
 def phitilde_vec_norm(
-    Nf: int, Nt: int, mult_f: int = 1, M: int = M_init, N: int = N_init, nu: float = nu_init, a_in=a_init
+    Nf: int, Nt: int, mult_f: int = 1, M: int = M_init, N: int = N_init, nu: float = nu_init
 ) -> NDArray[np.floating]:
-    """Normalize phitilde as needed for inverse frequency domain transform"""
+    """Normalize phitilde as needed for inverse frequency domain transform.
+
+    The window is sampled on the exact frequency-bin grid delta/Nt, delta = 0..mult_f*Nt/2,
+    so that tap delta multiplies rfft bin m*Nt/2 + delta (band edge y = 1/2 at delta = Nt/2).
+    """
     ND: int = Nf * Nt
-    # oms: NDArray[np.floating] = np.asarray(2 * np.pi / ND * np.arange(0, Nt // 2 + 1), dtype=float)
-    fn = np.linspace(0, 0.5 * mult_f, mult_f * Nt // 2 + 1, endpoint=False)
-    phif: NDArray[np.floating] = np.sqrt(np.pi) * np.sqrt(Nf) / 2 * phihat_eval(fn, M=M, N=N, nu=nu, a_in=a_in)
+    fn = np.arange(0, mult_f * Nt // 2 + 1) / Nt
+    phif: NDArray[np.floating] = np.sqrt(Nf / 2) * phihat_eval(fn, M=M, N=N, nu=nu)
     # nrm should be 1
     nrm: float = float(
-        np.sqrt((2 * np.sum(phif[1:] ** 2) + phif[0] ** 2) * 2 * np.pi / ND) / (np.pi ** (3 / 2) / np.pi),
+        np.sqrt((2 * np.sum(phif[1:] ** 2) + phif[0] ** 2) * 2 * np.pi / ND) / np.sqrt(np.pi),
     )
     return phif / nrm
 
 
 @njit()
-def phi_eval(xvals: NDArray[np.float64], M=M_init, N=N_init, nu=nu_init, a_in=a_init) -> NDArray[np.complex128]:
-    xvals = np.asarray(xvals)
+def _phi_eval_core(
+    xvals: NDArray[np.float64], M: int, N: int, nu: float, a_in: NDArray[np.complex128], prefactor: float
+) -> NDArray[np.complex128]:
+    assert a_in.shape == (2 * M + 1, 2 * N + 1)
+
     out = np.zeros_like(xvals, dtype=np.complex128)
 
-    itrp = 0
     for m in range(-M, M + 1):
         for n in range(-N, N + 1):
             coeff = a_in[m + M, n + N]
-            out += coeff * g_mn_x(xvals, m, n, nu_init)
+            out += coeff * g_mn_x(xvals, m, n, nu)
 
     return prefactor * out
+
+
+def phi_eval(
+    xvals: NDArray[np.float64], M: int = M_init, N: int = N_init, nu: float = nu_init
+) -> NDArray[np.complex128]:
+    """Time-domain window evaluated at arbitrary points, x in units of the pixel width."""
+    a_in, prefactor = get_mg_expansion(M=M, N=N, nu=nu)
+    return _phi_eval_core(np.asarray(xvals, dtype=np.float64), M, N, nu, a_in, prefactor)

--- a/WDMWaveletTransforms/transform_freq_funcs.py
+++ b/WDMWaveletTransforms/transform_freq_funcs.py
@@ -65,64 +65,6 @@ def tukey(data: NDArray[np.floating | np.complexfloating], alpha: float, N: int)
 
 
 @njit()
-def DX_assign_loop_old(
-    m: int,
-    Nt: int,
-    Nf: int,
-    mult_f: int,
-    DX: NDArray[np.complexfloating],
-    data: NDArray[np.complexfloating],
-    phif: NDArray[np.floating],
-) -> None:
-    """Helper for assigning DX in the main loop"""
-    assert len(DX.shape) == 1, 'Storage array must be 1D'
-    assert len(data.shape) == 1, 'Data must be 1D'
-    assert len(phif.shape) == 1, 'Phi array must be 1D'
-
-    assert 0 <= m <= Nf
-    assert Nf % 2 == 0
-    assert Nt % 2 == 0
-    assert Nf > 0
-    assert Nt > 0
-    assert mult_f > 0
-
-    K = mult_f * Nt
-    half_K = int(K // 2)
-    half_Nt = int(Nt // 2)
-
-    ND = Nf * Nt
-    half_ND = int(ND // 2)
-
-    assert phif.shape == (half_K + 1,)
-    assert DX.shape == (K,)
-    assert data.shape == (half_ND + 1,)
-
-    DX[:] = 0.0
-
-    i_base: int = mult_f * half_Nt
-    jj_base: int = m * half_Nt
-    if m in (0, Nf):
-        # NOTE this term appears to be needed to recover correct constant (at least for m=0) but was previously missing
-        DX[half_K] = phif[0] * data[m * half_Nt] / 2.0
-    else:
-        DX[half_K] = phif[0] * data[m * half_Nt]
-
-    # should never be set anywhere, but explicitly ensure it is 0
-    DX[0] = 0.0
-
-    for jj in range(jj_base + 1 - half_K, jj_base + half_K, mult_f):
-        j: int = int(np.abs(jj - jj_base))
-        i: int = i_base - jj_base + jj
-        if jj < 0 or jj > half_ND or (m == Nf and jj > jj_base) or (m == 0 and jj < jj_base):
-            DX[i] = 0.0
-        elif j == 0:
-            # happens when i == half_K, handled as special case above
-            continue
-        else:
-            DX[i] = phif[j] * data[jj]
-
-
-@njit()
 def DX_assign_loop(
     m: int,
     Nt: int,
@@ -132,7 +74,23 @@ def DX_assign_loop(
     data: NDArray[np.complexfloating],
     phif: NDArray[np.floating],
 ) -> None:
-    """Helper for assigning DX in the main loop"""
+    """Helper for assigning DX in the main loop.
+
+    Tap delta = i - K/2 multiplies the spectrum at bin jj = m*Nt/2 + delta.  For
+    interior bands, bins outside the rfft range [0, ND/2] are read from the full
+    conjugate-symmetric spectrum of the real signal: X[-jj] = conj(X[jj]) and
+    X[ND - jj] = conj(X[jj]) ("conjugate fold-back"), which makes the pixel the
+    exact inner product with the real wavelet even when the window crosses the
+    frequency extremes.  The self-conjugate bands m = 0 and m = Nf instead keep
+    only their own half-plane with the center tap halved: the reflection maps
+    the window onto itself there, so Re[] of the half sum is already the exact
+    fold.
+
+    Taps are alias-folded onto one Nt-period (the transform only ever needs the
+    length-K ifft at stride mult_f, which equals the length-Nt ifft of the
+    aliased taps), so DX has length Nt.  The unpaired tap at delta = -K/2 is
+    excluded: effective support is the open range delta in (-K/2, K/2).
+    """
     assert len(DX.shape) == 1, 'Storage array must be 1D'
     assert len(data.shape) == 1, 'Data must be 1D'
     assert len(phif.shape) == 1, 'Phi array must be 1D'
@@ -142,7 +100,7 @@ def DX_assign_loop(
     assert Nt % 2 == 0
     assert Nf > 0
     assert Nt > 0
-    assert mult_f > 0
+    assert 0 < mult_f <= Nf
 
     K = mult_f * Nt
     half_K = int(K // 2)
@@ -152,34 +110,44 @@ def DX_assign_loop(
     half_ND = int(ND // 2)
 
     assert phif.shape == (half_K + 1,)
-    assert DX.shape == (K,)
+    assert DX.shape == (Nt,)
     assert data.shape == (half_ND + 1,)
 
     DX[:] = 0.0
 
-    i_base: int = mult_f * half_Nt
-    jj_base: int = m * half_Nt
-    for i in range(K):
+    for i in range(1, K):
         j = abs(i - half_K)
         jj = m * half_Nt + i - half_K
         if j == 0:
             if m in (0, Nf):
-                # NOTE this term appears to be needed to recover correct constant (at least for m=0) but was previously missing
-                DX[i] = phif[j] * data[jj] / 2.0
+                # halve the self-conjugate center tap
+                DX[i % Nt] += phif[j] * data[jj] / 2.0
             else:
-                DX[i] = phif[j] * data[jj]
+                DX[i % Nt] += phif[j] * data[jj]
         elif jj < 0 or jj > half_ND:
-            DX[i] = 0.0
+            if m in (0, Nf):
+                # self-conjugate bands keep only their own half-plane
+                pass
+            elif jj < 0:
+                DX[i % Nt] += phif[j] * np.conj(data[-jj])
+            else:
+                DX[i % Nt] += phif[j] * np.conj(data[ND - jj])
         else:
-            DX[i] = phif[j] * data[jj]
-    DX[0] = 0.0
+            DX[i % Nt] += phif[j] * data[jj]
 
 
 @njit()
 def DX_unpack_loop(
     m: int, Nt: int, Nf: int, mult_f: int, DX_trans: NDArray[np.complexfloating], wave: NDArray[np.floating]
 ) -> None:
-    """Helper for unpacking fftd DX in main loop"""
+    """Helper for unpacking fftd DX in main loop.
+
+    DX_trans is the length-Nt ifft of the alias-folded taps; the tap positions
+    carry an offset of mult_f*Nt/2, so relative to the (-1)^n convention of the
+    analytic coefficient an extra factor (-1)^((mult_f+1)*n) appears, giving the
+    sign flips conditioned on the parity of mult_f below (n's parity is fixed by
+    the parities of m and n+m).
+    """
     assert len(DX_trans.shape) == 1, 'Data array must be 1D'
     assert len(wave.shape) == 2, 'Output array must be 2D'
 
@@ -190,36 +158,34 @@ def DX_unpack_loop(
     assert Nt > 0
     assert mult_f > 0
 
-    K = mult_f * Nt
-
-    assert DX_trans.shape == (K,)
+    assert DX_trans.shape == (Nt,)
     assert wave.shape == (Nt, Nf)
 
     if m == 0:
         # half of lowest and highest frequency bin pixels are redundant
         # so store them in even and odd components of m=0 respectively
         for n in range(0, Nt, 2):
-            wave[n, 0] = mult_f * DX_trans[n * mult_f].real * np.sqrt(2.0)
+            wave[n, 0] = DX_trans[n].real * np.sqrt(2.0)
     elif m == Nf:
         for n in range(0, Nt, 2):
-            wave[n + 1, 0] = mult_f * DX_trans[n * mult_f].real * np.sqrt(2.0)
+            wave[n + 1, 0] = DX_trans[n].real * np.sqrt(2.0)
     else:
         for n in range(Nt):
             if m % 2:
                 if (n + m) % 2:
-                    wave[n, m] = -mult_f * DX_trans[n * mult_f].imag
+                    wave[n, m] = -DX_trans[n].imag
                 else:
                     if mult_f % 2:
-                        wave[n, m] = mult_f * DX_trans[n * mult_f].real
+                        wave[n, m] = DX_trans[n].real
                     else:
-                        wave[n, m] = -mult_f * DX_trans[n * mult_f].real
+                        wave[n, m] = -DX_trans[n].real
             elif (n + m) % 2:
                 if mult_f % 2:
-                    wave[n, m] = mult_f * DX_trans[n * mult_f].imag
+                    wave[n, m] = DX_trans[n].imag
                 else:
-                    wave[n, m] = -mult_f * DX_trans[n * mult_f].imag
+                    wave[n, m] = -DX_trans[n].imag
             else:
-                wave[n, m] = mult_f * DX_trans[n * mult_f].real
+                wave[n, m] = DX_trans[n].real
 
 
 def transform_wavelet_freq_helper(
@@ -237,7 +203,7 @@ def transform_wavelet_freq_helper(
     assert Nt % 2 == 0
     assert Nf > 0
     assert Nt > 0
-    assert mult_f > 0
+    assert 0 < mult_f <= Nf, 'window must not wrap around the full spectrum'
 
     K = mult_f * Nt
 
@@ -245,29 +211,10 @@ def transform_wavelet_freq_helper(
     assert phif.shape == (K // 2 + 1,)
 
     wave = np.zeros((Nt, Nf))  # wavelet wavepacket transform of the signal
-    wave_alt = np.zeros((Nt, Nf))  # wavelet wavepacket transform of the signal
 
-    DX = np.zeros(K, dtype=complex)
-    # DX_alt = np.zeros(Nt, dtype=complex)
+    DX = np.zeros(Nt, dtype=complex)
     for m in range(Nf + 1):
         DX_assign_loop(m, Nt, Nf, mult_f, DX, data, phif)
-        # DX_assign_loop_old(m, Nt, Nf, 1, DX_alt, data, phif[:Nt//2+1])
-        # import matplotlib.pyplot as plt
-        # plt.plot(np.arange(-K//2, K//2), np.abs(DX))
-        # plt.plot(np.arange(-Nt//2, Nt//2), np.abs(DX_alt))
-        # plt.show()
-        # assert_allclose(DX[K//2:K//2+Nt//2], DX_alt[Nt//2:Nt//2+Nt//2], atol=1.e-100, rtol=1.e-10)
-        # assert_allclose(DX[K//2-Nt//2+1:K//2], DX_alt[1:Nt//2], atol=1.e-100, rtol=1.e-10)
-        DX_trans = fft.ifft(DX, K)
-        # DX_trans_alt = fft.ifft(DX_alt, Nt)
-        # plt.plot(np.linspace(-1., 1., K)[::mult_f], np.imag(DX_trans)[::mult_f]*mult_f)
-        # plt.plot(np.linspace(-1., 1., Nt), np.imag(DX_trans_alt))
-        # plt.show()
+        DX_trans = fft.ifft(DX, Nt)
         DX_unpack_loop(m, Nt, Nf, mult_f, DX_trans, wave)
-        # DX_unpack_loop(m, Nt, Nf, 1, DX_trans_alt, wave_alt)
-        # assert_allclose(wave[:,m]*mult_f, wave_alt[:,m], atol=1.e-2, rtol=1.e-2)
-        # if m == Nf:
-        #    plt.plot(wave[:,0]*mult_f)
-        #    plt.plot(wave_alt[:,0])
-        #    plt.show()
     return wave

--- a/WDMWaveletTransforms/wavelet_reference.py
+++ b/WDMWaveletTransforms/wavelet_reference.py
@@ -1,0 +1,237 @@
+"""Vectorized numpy reference implementations of the WDM frequency-domain transforms.
+
+This module is the executable specification of the transform conventions.  It is
+deliberately written with plain numpy array operations (no numba) so that every
+sign, parity, and boundary rule is visible in one place.  The production jitted
+helpers in transform_freq_funcs.py / inverse_wavelet_freq_funcs.py must agree with
+these functions to floating-point precision; the unit tests enforce that.
+
+Conventions implemented here (see the audit artifact for derivations):
+
+Forward transform of rfft data X[j], j = 0..ND/2 (ND = Nf*Nt, K = mult_f*Nt):
+
+  For each frequency band m the windowed analytic coefficient is
+
+      c_m[n] = ((-1)^n / Nt) * sum_{delta in (-K/2, K/2)}
+               phif[|delta|] * X_full[m*Nt/2 + delta] * exp(2j*pi*delta*n/Nt)
+
+  where X_full is the full conjugate-symmetric periodic spectrum of the real
+  signal, i.e. X_full[j] = X[j mod ND] with X[-j] = conj(X[j]).  Reading X_full
+  instead of zero-padding implements the exact inner product with the real
+  wavelet basis functions when the window crosses j = 0 or j = ND/2
+  ("conjugate fold-back"); for mult_f = 1 interior bands it reduces to the
+  original convention because the window never crosses.
+
+  Interior bands 0 < m < Nf store real coefficients with the parity table
+  (identical to the original mult_f = 1 implementation):
+
+      m odd,  n even: wave[n, m] = -Im c_m[n]
+      m odd,  n odd:  wave[n, m] = +Re c_m[n]
+      m even, n odd:  wave[n, m] = +Im c_m[n]
+      m even, n even: wave[n, m] = +Re c_m[n]
+
+  The m = 0 and m = Nf bands are self-conjugate: the reflection at j = 0
+  (resp. j = ND/2) maps the window onto itself, so the exact inner product is
+  implemented by keeping only delta >= 0 (resp. delta <= 0), halving the
+  center tap, and storing sqrt(2) * Re c in the even (resp. odd) rows of
+  column 0.
+
+Inverse transform (synthesis, the exact dual of the forward given a window
+satisfying the WDM orthonormality conditions):
+
+  For each interior band, F_m[l] = sum_n mult2_{nm} * wave[n, m] * exp(-2j*pi*n*l/Nt)
+  with mult2 = -1j if (n+m) odd else 1, and each window tap contributes
+
+      c = F_m[(m*Nt/2 + delta) mod Nt] * phif[|delta|]
+
+  at ring position jj = m*Nt/2 + delta.  Contributions landing outside the
+  rfft range fold back conjugated (the mirror lobe of the real atom):
+
+      target = jj mod ND
+      target == 0 or ND/2 : res[target] += 2*Re(c)
+      target <  ND/2      : res[target] += c
+      target >  ND/2      : res[ND - target] += conj(c)
+
+  m = 0 and m = Nf use the doubled-frequency packing of the original
+  implementation and scatter only their own half-plane, which is already the
+  complete synthesis for the self-conjugate atoms.
+
+  The tap at delta = -K/2 (the unpaired edge of the length-K window array) is
+  excluded everywhere, in both directions: effective support is the open range
+  delta in (-K/2, K/2).  (The original mult_f = 1 code added one such tap on
+  the inverse side for m = Nf only; it is invisible for the Meyer window,
+  which vanishes identically at |delta| = Nt/2, but would be inconsistent for
+  windows with unbounded support.)
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def _check_args(Nf: int, Nt: int, mult_f: int) -> None:
+    assert Nf > 0
+    assert Nt > 0
+    assert mult_f > 0
+    assert Nf % 2 == 0
+    assert Nt % 2 == 0
+    assert mult_f <= Nf, 'window must not wrap around the full spectrum'
+
+
+def _gather_spectrum_folded(
+    data: NDArray[np.complexfloating],
+    jj: NDArray[np.integer],
+    ND: int,
+) -> NDArray[np.complex128]:
+    """Read the full conjugate-symmetric periodic spectrum at (possibly out of range) bins jj.
+
+    data holds the rfft bins X[0..ND/2]; X_full[jj] = X[jj mod ND] with the
+    negative-frequency half given by conjugate symmetry.
+    """
+    jj_mod = np.mod(jj, ND)
+    fold = jj_mod > ND // 2
+    idx = np.where(fold, ND - jj_mod, jj_mod)
+    vals = np.asarray(data[idx], dtype=np.complex128)
+    vals[fold] = np.conj(vals[fold])
+    return vals
+
+
+def transform_wavelet_freq_reference(
+    data: NDArray[np.complexfloating],
+    Nf: int,
+    Nt: int,
+    mult_f: int,
+    phif: NDArray[np.floating],
+) -> NDArray[np.float64]:
+    """Reference forward transform from rfft data to wavelet pixels.
+
+    phif must already carry the overall normalization used by the production
+    helper (i.e. the 2/Nf-scaled normalized window).
+    """
+    _check_args(Nf, Nt, mult_f)
+    ND = Nf * Nt
+    K = mult_f * Nt
+    half_K = K // 2
+    half_Nt = Nt // 2
+
+    assert data.shape == (ND // 2 + 1,)
+    assert phif.shape == (half_K + 1,)
+
+    wave = np.zeros((Nt, Nf))
+
+    ns = np.arange(Nt)
+    sign_n = np.where(ns % 2 == 0, 1.0, -1.0)  # (-1)^n
+
+    # effective window support: open range delta in (-K/2, K/2)
+    deltas_int = np.arange(1 - half_K, half_K)  # interior bands
+    deltas_low = np.arange(0, half_K)  # m = 0 keeps delta >= 0
+    deltas_high = np.arange(1 - half_K, 1)  # m = Nf keeps delta <= 0
+
+    for m in range(Nf + 1):
+        if m == 0:
+            deltas = deltas_low
+        elif m == Nf:
+            deltas = deltas_high
+        else:
+            deltas = deltas_int
+
+        jj = m * half_Nt + deltas
+        W = phif[np.abs(deltas)] * _gather_spectrum_folded(data, jj, ND)
+        if m in (0, Nf):
+            # halve the self-conjugate center tap; Re[] then implements the
+            # exact fold of the reflection-symmetric atom
+            W[deltas == 0] *= 0.5
+
+        # alias the taps onto one Nt-period: exp(2j*pi*delta*n/Nt) depends
+        # only on delta mod Nt
+        w_alias = np.zeros(Nt, dtype=np.complex128)
+        np.add.at(w_alias, np.mod(deltas, Nt), W)
+
+        # c_m[n] = ((-1)^n / Nt) * sum_r w_alias[r] exp(2j*pi*r*n/Nt)
+        c_m = sign_n * np.fft.ifft(w_alias)
+
+        if m == 0:
+            wave[::2, 0] = np.sqrt(2.0) * c_m[::2].real
+        elif m == Nf:
+            wave[1::2, 0] = np.sqrt(2.0) * c_m[::2].real
+        elif m % 2:
+            wave[::2, m] = -c_m[::2].imag  # n even
+            wave[1::2, m] = c_m[1::2].real  # n odd
+        else:
+            wave[1::2, m] = c_m[1::2].imag  # n odd
+            wave[::2, m] = c_m[::2].real  # n even
+
+    return wave
+
+
+def _scatter_folded(
+    res: NDArray[np.complexfloating],
+    jj: NDArray[np.integer],
+    contrib: NDArray[np.complexfloating],
+    ND: int,
+) -> None:
+    """Scatter-add synthesis contributions at ring bins jj into the rfft array res.
+
+    Contributions at bins outside [0, ND/2] are the mirror lobe of the real
+    atom and fold back conjugated; the self-conjugate bins 0 and ND/2 receive
+    both lobes at once (2 Re).
+    """
+    target = np.mod(jj, ND)
+    self_conj = (target == 0) | (target == ND // 2)
+    upper = target > ND // 2
+
+    np.add.at(res, target[self_conj], 2.0 * contrib[self_conj].real)
+    direct = ~self_conj & ~upper
+    np.add.at(res, target[direct], contrib[direct])
+    np.add.at(res, ND - target[upper], np.conj(contrib[upper]))
+
+
+def inverse_wavelet_freq_reference(
+    wave_in: NDArray[np.floating],
+    Nf: int,
+    Nt: int,
+    mult_f: int,
+    phif: NDArray[np.floating],
+) -> NDArray[np.complex128]:
+    """Reference inverse transform from wavelet pixels to rfft data.
+
+    phif is the normalized window without the 2/Nf forward scaling.
+    """
+    _check_args(Nf, Nt, mult_f)
+    ND = Nf * Nt
+    K = mult_f * Nt
+    half_K = K // 2
+    half_Nt = Nt // 2
+
+    assert wave_in.shape == (Nt, Nf)
+    assert phif.shape == (half_K + 1,)
+
+    res = np.zeros(ND // 2 + 1, dtype=np.complex128)
+
+    ns = np.arange(Nt)
+
+    deltas_int = np.arange(1 - half_K, half_K)
+    deltas_low = np.arange(0, half_K)
+    deltas_high = np.arange(1 - half_K, 1)
+
+    for m in range(Nf + 1):
+        if m in (0, Nf):
+            # doubled-frequency packing of the self-conjugate bands
+            col = wave_in[np.mod(2 * ns, Nt), 0] if m == 0 else wave_in[np.mod(2 * ns, Nt) + 1, 0]
+            a = col / np.sqrt(2.0)
+            F_m = np.fft.fft(a)
+            deltas = deltas_low if m == 0 else deltas_high
+            jj = m * half_Nt + deltas
+            contrib = F_m[np.mod(2 * jj, Nt)] * phif[np.abs(deltas)]
+            # single-lobe scatter: the self-conjugate atoms stay inside [0, ND/2]
+            res[jj] += contrib
+            continue
+
+        mult2 = np.where((ns + m) % 2 == 1, -1j, 1.0 + 0j)
+        a = mult2 * wave_in[:, m]
+        F_m = np.fft.fft(a)
+
+        jj = m * half_Nt + deltas_int
+        contrib = F_m[np.mod(jj, Nt)] * phif[np.abs(deltas_int)]
+        _scatter_folded(res, jj, contrib, ND)
+
+    return res

--- a/WDMWaveletTransforms/wavelet_transforms.py
+++ b/WDMWaveletTransforms/wavelet_transforms.py
@@ -7,8 +7,8 @@ import WDMWaveletTransforms.fft_funcs as fft
 import WDMWaveletTransforms.modified_gaussian as mg
 from WDMWaveletTransforms.inverse_wavelet_freq_funcs import inverse_wavelet_freq_helper_fast
 from WDMWaveletTransforms.inverse_wavelet_time_funcs import inverse_wavelet_time_helper_fast
-from WDMWaveletTransforms.transform_freq_funcs import transform_wavelet_freq_helper
-from WDMWaveletTransforms.transform_time_funcs import transform_wavelet_time_helper
+from WDMWaveletTransforms.transform_freq_funcs import phitilde_vec_norm, transform_wavelet_freq_helper
+from WDMWaveletTransforms.transform_time_funcs import phi_vec, transform_wavelet_time_helper
 
 __all__ = [
     'inverse_wavelet_freq',
@@ -19,6 +19,31 @@ __all__ = [
     'transform_wavelet_time',
 ]
 
+WAVELET_FAMILIES = ('meyer', 'modified_gaussian')
+
+
+def _get_phif(Nf: int, Nt: int, nx: float, mult_f: int, family: str) -> NDArray[np.float64]:
+    """Normalized frequency-domain window for the requested wavelet family.
+
+    nx (filter steepness) applies to the Meyer family only.
+    """
+    if family == 'meyer':
+        return phitilde_vec_norm(Nf, Nt, nx, mult_f)
+    if family == 'modified_gaussian':
+        return np.asarray(mg.phitilde_vec_norm(Nf, Nt, mult_f), dtype=np.float64)
+    msg = f'unrecognized wavelet family: {family!r}, expected one of {WAVELET_FAMILIES}'
+    raise ValueError(msg)
+
+
+def _get_phi(Nf: int, nx: float, mult: int, family: str) -> NDArray[np.float64]:
+    """Time-domain window of length K = 2*mult*Nf for the requested wavelet family."""
+    if family == 'meyer':
+        return phi_vec(Nf, nx=nx, mult=mult)
+    if family == 'modified_gaussian':
+        return mg.phi_vec(Nf, mult_t=mult)
+    msg = f'unrecognized wavelet family: {family!r}, expected one of {WAVELET_FAMILIES}'
+    raise ValueError(msg)
+
 
 def inverse_wavelet_time(
     wave_in: NDArray[np.float64],
@@ -26,32 +51,41 @@ def inverse_wavelet_time(
     Nt: int,
     nx: float = 4.0,
     mult: int = 32,
+    family: str = 'meyer',
 ) -> NDArray[np.float64]:
     """Fast inverse wavelet transform to time domain"""
     assert len(wave_in.shape) == 2, 'Only 2D Arrays supported currently'
     mult = int(min(mult, int(Nt // 2)))  # make sure K isn't bigger than ND
-    # phi: NDArray[np.float64] = phi_vec(Nf, nx=nx, mult=mult) / 2
-    phi: NDArray[np.float64] = mg.phi_vec(Nf=Nf, mult=mult) / 2
+    phi: NDArray[np.float64] = _get_phi(Nf, nx, mult, family) / 2
 
     return inverse_wavelet_time_helper_fast(wave_in, phi, Nf, Nt, mult)
 
 
 def inverse_wavelet_freq(
-    wave_in: NDArray[np.float64], Nf: int, Nt: int, nx: float = 4.0, mult_f: int = 1
+    wave_in: NDArray[np.float64],
+    Nf: int,
+    Nt: int,
+    nx: float = 4.0,
+    mult_f: int = 1,
+    family: str = 'meyer',
 ) -> NDArray[np.complex128]:
     """Inverse wavelet transform to freq domain signal"""
     assert len(wave_in.shape) == 2, 'Only 2D Arrays supported currently'
-    # phif: NDArray[np.float64] = phitilde_vec_norm(Nf, Nt, nx, mult_f)
-    phif: NDArray[np.float64] = mg.phitilde_vec_norm(Nf, Nt, mult_f)
+    phif: NDArray[np.float64] = _get_phif(Nf, Nt, nx, mult_f, family)
     return inverse_wavelet_freq_helper_fast(wave_in, phif, Nf, Nt, mult_f)
 
 
 def inverse_wavelet_freq_time(
-    wave_in: NDArray[np.float64], Nf: int, Nt: int, nx: float = 4.0, mult_f: int = 1
+    wave_in: NDArray[np.float64],
+    Nf: int,
+    Nt: int,
+    nx: float = 4.0,
+    mult_f: int = 1,
+    family: str = 'meyer',
 ) -> NDArray[np.float64]:
     """Inverse wavlet transform to time domain via fourier transform of frequency domain"""
     assert len(wave_in.shape) == 2, 'Only 2D Arrays supported currently'
-    res_f: NDArray[np.complex128] = inverse_wavelet_freq(wave_in, Nf, Nt, nx, mult_f)
+    res_f: NDArray[np.complex128] = inverse_wavelet_freq(wave_in, Nf, Nt, nx, mult_f, family)
     return fft.irfft(res_f)
 
 
@@ -61,6 +95,7 @@ def transform_wavelet_time(
     Nt: int,
     nx: float = 4.0,
     mult: int = 32,
+    family: str = 'meyer',
 ) -> NDArray[np.float64]:
     """Do the wavelet transform in the time domain,
     note there can be significant leakage if mult is too small and the
@@ -68,26 +103,34 @@ def transform_wavelet_time(
     """
     assert len(data.shape) == 1, 'Only 1D Arrays supported currently'
     mult = int(min(mult, int(Nt // 2)))  # make sure K isn't bigger than ND
-    # phi: NDArray[np.float64] = phi_vec(Nf, nx, mult)
-    phi: NDArray[np.float64] = mg.phi_vec(Nf=Nf, mult=mult)
+    phi: NDArray[np.float64] = _get_phi(Nf, nx, mult, family)
     return transform_wavelet_time_helper(data, Nf, Nt, phi, mult)
 
 
 def transform_wavelet_freq(
-    data: NDArray[np.complex128], Nf: int, Nt: int, nx: float = 4.0, mult_f: int = 1
+    data: NDArray[np.complex128],
+    Nf: int,
+    Nt: int,
+    nx: float = 4.0,
+    mult_f: int = 1,
+    family: str = 'meyer',
 ) -> NDArray[np.float64]:
     """Do the wavelet transform using the fast wavelet domain transform"""
     assert len(data.shape) == 1, 'Only 1D Arrays supported currently'
-    # phif: NDArray[np.float64] = 2 / Nf * phitilde_vec_norm(Nf, Nt, nx, mult_f)
-    phif: NDArray[np.float64] = 2 / Nf * mg.phitilde_vec_norm(Nf, Nt, mult_f)
+    phif: NDArray[np.float64] = 2 / Nf * _get_phif(Nf, Nt, nx, mult_f, family)
     return transform_wavelet_freq_helper(data, Nf, Nt, mult_f, phif)
 
 
 def transform_wavelet_freq_time(
-    data: NDArray[np.float64], Nf: int, Nt: int, nx: float = 4.0, mult_f: int = 1
+    data: NDArray[np.float64],
+    Nf: int,
+    Nt: int,
+    nx: float = 4.0,
+    mult_f: int = 1,
+    family: str = 'meyer',
 ) -> NDArray[np.float64]:
     """Transform time domain data into wavelet domain via fft and then frequency transform"""
     assert len(data.shape) == 1, 'Only 1D Arrays supported currently'
     data_fft: NDArray[np.complex128] = fft.rfft(data)
 
-    return transform_wavelet_freq(data_fft, Nf, Nt, nx=nx, mult_f=mult_f)
+    return transform_wavelet_freq(data_fft, Nf, Nt, nx=nx, mult_f=mult_f, family=family)

--- a/benchmark_transforms.py
+++ b/benchmark_transforms.py
@@ -1,0 +1,61 @@
+"""Speed comparison of the numba-jitted frequency-domain transforms against the
+plain-numpy reference implementations in WDMWaveletTransforms.wavelet_reference.
+
+Run directly: python benchmark_transforms.py
+"""
+# ruff: noqa: T201
+
+from functools import partial
+from time import perf_counter
+from typing import Callable
+
+import numpy as np
+
+import WDMWaveletTransforms.modified_gaussian as mg
+from WDMWaveletTransforms.inverse_wavelet_freq_funcs import inverse_wavelet_freq_helper_fast
+from WDMWaveletTransforms.transform_freq_funcs import transform_wavelet_freq_helper
+from WDMWaveletTransforms.wavelet_reference import (
+    inverse_wavelet_freq_reference,
+    transform_wavelet_freq_reference,
+)
+
+
+def _time(fn: Callable[[], object], n_rep: int = 3) -> float:
+    best = np.inf
+    for _ in range(n_rep):
+        t0 = perf_counter()
+        fn()
+        best = min(best, perf_counter() - t0)
+    return best
+
+
+if __name__ == '__main__':
+    rng = np.random.default_rng(31415)
+
+    for Nf, Nt, mult_f in [(256, 256, 4), (512, 512, 8), (2048, 1024, 8)]:
+        ND = Nf * Nt
+        data = rng.normal(size=ND // 2 + 1) + 1j * rng.normal(size=ND // 2 + 1)
+        data[0] = data[0].real
+        data[-1] = data[-1].real
+
+        phin = np.asarray(mg.phitilde_vec_norm(Nf, Nt, mult_f), dtype=np.float64)
+        phif_fwd = 2 / Nf * phin
+
+        # warm up jit compilation before timing
+        wave = transform_wavelet_freq_helper(data, Nf, Nt, mult_f, phif_fwd)
+        inverse_wavelet_freq_helper_fast(wave, phin, Nf, Nt, mult_f)
+
+        t_fwd_jit = _time(partial(transform_wavelet_freq_helper, data, Nf, Nt, mult_f, phif_fwd))
+        t_fwd_ref = _time(partial(transform_wavelet_freq_reference, data, Nf, Nt, mult_f, phif_fwd))
+        t_inv_jit = _time(partial(inverse_wavelet_freq_helper_fast, wave, phin, Nf, Nt, mult_f))
+        t_inv_ref = _time(partial(inverse_wavelet_freq_reference, wave, Nf, Nt, mult_f, phin))
+
+        print(f'Nf={Nf} Nt={Nt} mult_f={mult_f}:')
+        print(
+            f'  forward  jitted {t_fwd_jit * 1e3:8.1f} ms   reference {t_fwd_ref * 1e3:8.1f} ms   '
+            f'ratio {t_fwd_ref / t_fwd_jit:5.2f}x'
+        )
+        print(
+            f'  inverse  jitted {t_inv_jit * 1e3:8.1f} ms   reference {t_inv_ref * 1e3:8.1f} ms   '
+            f'ratio {t_inv_ref / t_inv_jit:5.2f}x'
+        )

--- a/test_mg_freq.py
+++ b/test_mg_freq.py
@@ -39,10 +39,8 @@ if __name__ == '__main__':
     data_freq[0] = np.real(data_freq[0])
     data_freq[-1] = np.real(data_freq[-1])
 
-    data_wavelet = transform_wavelet_freq(data_freq, Nf, Nt, mult_f=mult_f)
-    # TODO temporary fudge until normalization issue handled
-    # data_wavelet = data_wavelet / (np.std(data_wavelet))
-    data_freq_rec = inverse_wavelet_freq(data_wavelet, Nf, Nt, mult_f=mult_f)
+    data_wavelet = transform_wavelet_freq(data_freq, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    data_freq_rec = inverse_wavelet_freq(data_wavelet, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
 
     print(scale * np.var(data_wavelet) / np.var(data_freq))
     print(np.mean(data_freq_rec / data_freq), np.var(data_freq_rec) / np.var(data_freq))
@@ -67,7 +65,8 @@ if __name__ == '__main__':
     assert_allclose(1.0 - np.corrcoef(np.real(data_freq), np.real(data_freq_rec))[0, 1], 0.0, atol=1.0e-5)
     assert_allclose(1.0 - np.corrcoef(np.imag(data_freq), np.imag(data_freq_rec))[0, 1], 0.0, atol=1.0e-4)
     assert_allclose(1.0 - np.corrcoef(np.abs(data_freq), np.abs(data_freq_rec))[0, 1], 0.0, atol=1.0e-4)
-    assert_allclose(1.0 - np.corrcoef(np.angle(data_freq), np.angle(data_freq_rec))[0, 1], 0.0, atol=1.0e-14)
+    # residual set by the frequency-window tail truncated at mult_f*Nt/2 bins
+    assert_allclose(1.0 - np.corrcoef(np.angle(data_freq), np.angle(data_freq_rec))[0, 1], 0.0, atol=1.0e-11)
 
     # check variance preserved for parseval's theorem
     assert_allclose(np.sum(data_wavelet**2), parseval_rfft(data_freq, Nf * Nt), atol=1.0e-100, rtol=1.0e-6)
@@ -92,7 +91,7 @@ if __name__ == '__main__':
         np.mean(np.abs(data_freq)) / scale, np.mean(np.abs(data_freq_rec)) / scale, atol=1.0e-100, rtol=1.0e-7
     )
     assert_allclose(
-        np.mean(np.angle(data_freq)) / scale, np.mean(np.angle(data_freq_rec)) / scale, atol=1.0e-13, rtol=1.0e-7
+        np.mean(np.angle(data_freq)) / scale, np.mean(np.angle(data_freq_rec)) / scale, atol=1.0e-11, rtol=1.0e-5
     )
 
     unit_normal_battery(data_wavelet.flatten())
@@ -108,7 +107,7 @@ if __name__ == '__main__':
     corr_wave[Nt // 2, Nf // 2] = 0.0
     assert_allclose(corr_wave, 0.0, atol=4.0e-3)
     assert_allclose(np.mean(corr_wave), 0.0, atol=3.0e-7)
-    assert_allclose(np.std(corr_wave) * 4 / 3 * np.sqrt(Nt * Nf), 1.0, atol=3.0e-5)
+    assert_allclose(np.std(corr_wave) * 4 / 3 * np.sqrt(Nt * Nf), 1.0, atol=1.0e-3)
     assert_allclose(np.mean(corr_wave, axis=0), 0.0, atol=1.0e-4)
     assert_allclose(np.mean(corr_wave, axis=1), 0.0, atol=1.0e-4)
 

--- a/test_mg_freq_time.py
+++ b/test_mg_freq_time.py
@@ -21,17 +21,17 @@ if __name__ == '__main__':
 
     data_time = gen.normal(0.0, 1.0, Nf * Nt)
 
-    data_wavelet1 = transform_wavelet_time(data_time, Nf, Nt, mult=mult)
-    data_wavelet2 = transform_wavelet_freq_time(data_time, Nf, Nt, mult_f=mult_f)
+    data_wavelet1 = transform_wavelet_time(data_time, Nf, Nt, mult=mult, family='modified_gaussian')
+    data_wavelet2 = transform_wavelet_freq_time(data_time, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
 
     assert_allclose(np.var(data_wavelet1), np.var(data_wavelet2), atol=1.0e-10, rtol=1.0e-3)
     # assert_allclose(np.mean(data_wavelet1), np.mean(data_wavelet2), atol=1.e-10, rtol=1.e-4)
 
-    data_time_rec1 = inverse_wavelet_time(data_wavelet1, Nf, Nt, mult=mult)
-    data_time_rec1_2 = inverse_wavelet_freq_time(data_wavelet1, Nf, Nt, mult_f=mult_f)
-    data_time_rec2 = inverse_wavelet_time(data_wavelet2, Nf, Nt, mult=mult)
-    data_time_rec2_2 = inverse_wavelet_freq_time(data_wavelet2, Nf, Nt, mult_f=mult_f)
-    data_wavelet3 = transform_wavelet_time(data_time_rec1_2, Nf, Nt, mult=mult)
+    data_time_rec1 = inverse_wavelet_time(data_wavelet1, Nf, Nt, mult=mult, family='modified_gaussian')
+    data_time_rec1_2 = inverse_wavelet_freq_time(data_wavelet1, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    data_time_rec2 = inverse_wavelet_time(data_wavelet2, Nf, Nt, mult=mult, family='modified_gaussian')
+    data_time_rec2_2 = inverse_wavelet_freq_time(data_wavelet2, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    data_wavelet3 = transform_wavelet_time(data_time_rec1_2, Nf, Nt, mult=mult, family='modified_gaussian')
 
     # check correlation of streams
     assert_allclose(1.0 - np.corrcoef(data_time, data_time_rec1)[0, 1], 0.0, atol=1.0e-14)

--- a/test_mg_time.py
+++ b/test_mg_time.py
@@ -95,8 +95,8 @@ if __name__ == '__main__':
 
     data_time = gen.normal(0.0, 1.0, Nf * Nt)
 
-    data_wavelet = transform_wavelet_time(data_time, Nf, Nt, mult=mult)
-    data_time_rec = inverse_wavelet_time(data_wavelet, Nf, Nt, mult=mult)
+    data_wavelet = transform_wavelet_time(data_time, Nf, Nt, mult=mult, family='modified_gaussian')
+    data_time_rec = inverse_wavelet_time(data_wavelet, Nf, Nt, mult=mult, family='modified_gaussian')
     # check correlation of streams
     assert_allclose(1.0 - np.corrcoef(data_time, data_time_rec)[0, 1], 0.0, atol=1.0e-14)
     # check variance preserved for parseval's theorem

--- a/tests/wavelet_convention_test.py
+++ b/tests/wavelet_convention_test.py
@@ -1,0 +1,374 @@
+"""Unit tests for the WDM transform conventions, edge cases, and regression guards.
+
+These tests pin down the sign/parity conventions, the m = 0 / m = Nf packing, the
+mult_f oversampling phases, and the conjugate fold-back at the frequency-domain
+extremes, for both the Meyer and modified-Gaussian wavelet families.  The jitted
+production helpers are checked against the plain-numpy reference implementations
+in WDMWaveletTransforms.wavelet_reference and against closed-form time-domain
+atoms constructed directly from the window.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.fft import fftn
+
+import WDMWaveletTransforms.modified_gaussian as mg
+from WDMWaveletTransforms.inverse_wavelet_freq_funcs import inverse_wavelet_freq_helper_fast
+from WDMWaveletTransforms.transform_freq_funcs import phitilde_vec_norm, transform_wavelet_freq_helper
+from WDMWaveletTransforms.wavelet_reference import (
+    inverse_wavelet_freq_reference,
+    transform_wavelet_freq_reference,
+)
+from WDMWaveletTransforms.wavelet_transforms import (
+    inverse_wavelet_freq,
+    inverse_wavelet_freq_time,
+    inverse_wavelet_time,
+    transform_wavelet_freq,
+    transform_wavelet_freq_time,
+    transform_wavelet_time,
+)
+
+
+def _rand_rfft(ND: int, rng: np.random.Generator) -> np.ndarray:
+    data = rng.normal(size=ND // 2 + 1) + 1j * rng.normal(size=ND // 2 + 1)
+    data[0] = data[0].real
+    data[-1] = data[-1].real
+    return data
+
+
+def _get_phin(family: str, Nf: int, Nt: int, mult_f: int) -> np.ndarray:
+    if family == 'meyer':
+        return phitilde_vec_norm(Nf, Nt, 4.0, mult_f)
+    return np.asarray(mg.phitilde_vec_norm(Nf, Nt, mult_f), dtype=np.float64)
+
+
+def _phi_K_kernel(phif: np.ndarray, ND: int, K: int) -> np.ndarray:
+    """Closed-form truncated window kernel Phi_K(tau) for tau = 0..ND-1."""
+    taus = np.arange(ND)
+    deltas = np.arange(1 - K // 2, K // 2)
+    return np.real(
+        np.sum(phif[np.abs(deltas)][None, :] * np.exp(2j * np.pi * deltas[None, :] * taus[:, None] / ND), axis=1)
+    )
+
+
+def _atom(n: int, m: int, Nf: int, Nt: int, PhiK: np.ndarray) -> np.ndarray:
+    """Closed-form time-domain analysis atom for pixel (n, m), forward-scaled window."""
+    ND = Nf * Nt
+    ks = np.arange(ND)
+    kappa_mod = np.mod(ks - n * Nf, ND)
+    Pk = PhiK[kappa_mod]
+    kap = ks - n * Nf
+    if m == 0:
+        return Pk / (np.sqrt(2.0) * Nt)
+    if m == Nf:
+        return Pk * np.cos(np.pi * kap) / (np.sqrt(2.0) * Nt)
+    if (n + m) % 2 == 0:
+        return Pk * np.cos(np.pi * m * kap / Nf) / Nt
+    return Pk * np.sin(np.pi * m * kap / Nf) / Nt
+
+
+# ---------------------------------------------------------------------------
+# jitted implementation must match the reference implementation exactly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('family', ['meyer', 'modified_gaussian'])
+@pytest.mark.parametrize(('Nf', 'Nt'), [(8, 16), (16, 8), (32, 64)])
+@pytest.mark.parametrize('mult_f', [1, 2, 3, 4])
+def test_jit_matches_reference(family: str, Nf: int, Nt: int, mult_f: int) -> None:
+    """Forward and inverse jitted helpers agree with the numpy reference to fp precision,
+    covering both parities of mult_f (the parity enters the unpacking phases).
+    """
+    rng = np.random.default_rng(101)
+    ND = Nf * Nt
+    phin = _get_phin(family, Nf, Nt, mult_f)
+    phif_fwd = 2 / Nf * phin
+    data = _rand_rfft(ND, rng)
+
+    w_ref = transform_wavelet_freq_reference(data, Nf, Nt, mult_f, phif_fwd)
+    w_jit = transform_wavelet_freq_helper(data, Nf, Nt, mult_f, phif_fwd)
+    assert_allclose(w_jit, w_ref, atol=1.0e-13 * np.max(np.abs(w_ref)), rtol=0.0)
+
+    r_ref = inverse_wavelet_freq_reference(w_ref, Nf, Nt, mult_f, phin)
+    r_jit = inverse_wavelet_freq_helper_fast(w_ref, phin, Nf, Nt, mult_f)
+    assert_allclose(r_jit, r_ref, atol=1.0e-13 * np.max(np.abs(r_ref)), rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# closed-form time-domain atoms pin the analysis conventions without any ffts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('family', ['meyer', 'modified_gaussian'])
+@pytest.mark.parametrize('mult_f', [1, 2, 3])
+def test_forward_matches_closed_form_atoms(family: str, mult_f: int) -> None:
+    """wave[n, m] equals the inner product of the signal with the closed-form real atom:
+    Phi_K(k - n*Nf)/Nt times cos (n+m even) or sin (n+m odd) of pi*m*(k - n*Nf)/Nf,
+    with the m = 0 / m = Nf atoms at 1/sqrt(2) amplitude in the even/odd rows of column 0.
+    """
+    Nf, Nt = 8, 16
+    ND = Nf * Nt
+    K = mult_f * Nt
+    rng = np.random.default_rng(202)
+    phin = _get_phin(family, Nf, Nt, mult_f)
+    phif_fwd = 2 / Nf * phin
+    PhiK = _phi_K_kernel(phif_fwd, ND, K)
+
+    data = _rand_rfft(ND, rng)
+    x_time = np.fft.irfft(data)
+    w_jit = transform_wavelet_freq_helper(data, Nf, Nt, mult_f, phif_fwd)
+
+    wave_bf = np.zeros((Nt, Nf))
+    for n in range(Nt):
+        for m in range(Nf + 1):
+            val = float(np.dot(x_time, _atom(n, m, Nf, Nt, PhiK)))
+            if m == 0:
+                if n % 2 == 0:
+                    wave_bf[n, 0] = val
+            elif m == Nf:
+                if n % 2 == 0:
+                    wave_bf[n + 1, 0] = val
+            else:
+                wave_bf[n, m] = val
+
+    assert_allclose(w_jit, wave_bf, atol=1.0e-12 * np.max(np.abs(wave_bf)), rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# round-trip identities and their convergence with mult_f
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('mult_f', [1, 2, 3])
+def test_roundtrip_meyer_exact(mult_f: int) -> None:
+    """The Meyer window has compact support, so the round trip is exact at any mult_f."""
+    Nf, Nt = 16, 32
+    ND = Nf * Nt
+    rng = np.random.default_rng(303)
+    data = _rand_rfft(ND, rng)
+    w = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f)
+    rec = inverse_wavelet_freq(w, Nf, Nt, mult_f=mult_f)
+    assert_allclose(rec, data, atol=1.0e-13 * np.max(np.abs(data)), rtol=0.0)
+
+
+@pytest.mark.parametrize(('mult_f', 'tol'), [(4, 5.0e-3), (8, 1.0e-5), (16, 1.0e-10), (24, 5.0e-13)])
+def test_roundtrip_mg_convergence(mult_f: int, tol: float) -> None:
+    """The modified-Gaussian round-trip error is set by the window tail truncated at
+    |delta| = mult_f*Nt/2 and must fall with mult_f down to machine precision.
+    Guards the window grid, the fold-back, and all packing conventions at once.
+    """
+    Nf, Nt = 32, 64
+    ND = Nf * Nt
+    rng = np.random.default_rng(404)
+    data = _rand_rfft(ND, rng)
+    w = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    rec = inverse_wavelet_freq(w, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    err = np.max(np.abs(rec - data)) / np.max(np.abs(data))
+    assert err < tol
+
+
+def test_roundtrip_wave_side_identity() -> None:
+    """The transform is a square map, so forward(inverse(wave)) = wave as well."""
+    Nf, Nt = 16, 32
+    rng = np.random.default_rng(505)
+    wave = rng.normal(size=(Nt, Nf))
+    mult_f = 16
+    data = inverse_wavelet_freq(wave, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    wave_rec = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    assert_allclose(wave_rec, wave, atol=1.0e-10 * np.max(np.abs(wave)), rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# boundary and edge-case behavior at the frequency extremes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('jbin', [0, 1, 8, 16, 511, 512])
+def test_delta_function_bins_roundtrip(jbin: int) -> None:
+    """Spectra concentrated at the boundary bins (DC, Nyquist, and neighbors) survive
+    the round trip: these bins are exactly where the fold-back conventions act.
+    """
+    Nf, Nt = 32, 32
+    ND = Nf * Nt
+    mult_f = 16
+    data = np.zeros(ND // 2 + 1, dtype=np.complex128)
+    data[jbin] = 1.0 if jbin in (0, ND // 2) else 1.0 + 0.5j
+    w = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    rec = inverse_wavelet_freq(w, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    assert_allclose(rec, data, atol=2.0e-11, rtol=0.0)
+
+
+def test_dc_and_nyquist_bins_stay_real() -> None:
+    """Reconstruction keeps the self-conjugate bins real (2 Re fold at j = 0, ND/2)."""
+    Nf, Nt = 16, 32
+    ND = Nf * Nt
+    rng = np.random.default_rng(606)
+    data = _rand_rfft(ND, rng)
+    for mult_f in (3, 4):
+        w = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+        rec = inverse_wavelet_freq(w, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+        assert abs(rec[0].imag) < 1.0e-13 * np.max(np.abs(data))
+        assert abs(rec[ND // 2].imag) < 1.0e-13 * np.max(np.abs(data))
+
+
+def test_m0_nf_column_packing() -> None:
+    """Half of the lowest and highest frequency bands are redundant; the lowest band is
+    stored in the even rows of column 0 and the highest band in the odd rows.
+    """
+    Nf, Nt = 16, 32
+    ND = Nf * Nt
+    mult_f = 8
+    rng = np.random.default_rng(707)
+
+    # spectrum supported strictly inside the lowest band only
+    data_low = np.zeros(ND // 2 + 1, dtype=np.complex128)
+    data_low[: Nt // 4] = rng.normal(size=Nt // 4) + 1j * rng.normal(size=Nt // 4)
+    data_low[0] = data_low[0].real
+    w = transform_wavelet_freq(data_low, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    frac_odd = np.max(np.abs(w[1::2, 0])) / np.max(np.abs(w[::2, 0]))
+    assert frac_odd < 1.0e-10  # no leakage into the m = Nf storage rows
+
+    # spectrum supported strictly inside the highest band only
+    data_high = np.zeros(ND // 2 + 1, dtype=np.complex128)
+    data_high[-Nt // 4 :] = rng.normal(size=Nt // 4) + 1j * rng.normal(size=Nt // 4)
+    data_high[-1] = data_high[-1].real
+    w = transform_wavelet_freq(data_high, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    frac_even = np.max(np.abs(w[::2, 0])) / np.max(np.abs(w[1::2, 0]))
+    assert frac_even < 1.0e-10  # no leakage into the m = 0 storage rows
+
+
+def test_single_pixel_boundary_atoms_roundtrip() -> None:
+    """Single-pixel wavelet arrays at the corner/boundary pixels reproduce themselves,
+    including the special m = 0 / m = Nf rows and both n parities.
+    """
+    Nf, Nt = 16, 16
+    mult_f = 16
+    for n, m_col in [(0, 0), (1, 0), (2, 0), (3, 0), (0, 1), (1, 1), (Nt - 1, Nf - 1), (0, Nf - 1), (5, 8)]:
+        wave = np.zeros((Nt, Nf))
+        wave[n, m_col] = 1.0
+        data = inverse_wavelet_freq(wave, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+        wave_rec = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+        assert_allclose(wave_rec, wave, atol=5.0e-11, rtol=0.0, err_msg=f'pixel ({n}, {m_col})')
+
+
+def test_mult_f_must_not_wrap() -> None:
+    """mult_f > Nf would wrap the window around the full spectrum and is rejected."""
+    Nf, Nt = 4, 8
+    data = np.zeros(Nf * Nt // 2 + 1, dtype=np.complex128)
+    with pytest.raises(AssertionError):
+        transform_wavelet_freq(data, Nf, Nt, mult_f=Nf + 1, family='modified_gaussian')
+
+
+# ---------------------------------------------------------------------------
+# normalization and window construction guards
+# ---------------------------------------------------------------------------
+
+
+def test_parseval_mg() -> None:
+    """Total wavelet-domain power equals the Parseval sum of the input spectrum."""
+    Nf, Nt = 32, 64
+    ND = Nf * Nt
+    mult_f = 8
+    rng = np.random.default_rng(808)
+    data = _rand_rfft(ND, rng)
+    w = transform_wavelet_freq(data, Nf, Nt, mult_f=mult_f, family='modified_gaussian')
+    pars = 1 / ND * (np.abs(data[0]) ** 2 + np.abs(data[-1]) ** 2 + 2 * np.sum(np.abs(data[1:-1]) ** 2))
+    assert_allclose(np.sum(w**2), pars, rtol=1.0e-6)
+
+
+def test_phitilde_mg_grid() -> None:
+    """The window taps must sit on the exact bin grid delta/Nt: tap delta of
+    phitilde_vec_norm is proportional to phihat_eval(delta/Nt) with one global constant.
+    Guards against off-by-one/linspace-endpoint grid regressions.
+    """
+    Nf, Nt, mult_f = 16, 32, 4
+    phin = np.asarray(mg.phitilde_vec_norm(Nf, Nt, mult_f), dtype=np.float64)
+    direct = np.asarray(mg.phihat_eval(np.arange(0, mult_f * Nt // 2 + 1) / Nt), dtype=np.float64)
+    mask = np.abs(direct) > 1.0e-8 * np.max(np.abs(direct))
+    ratios = phin[mask] / direct[mask]
+    assert_allclose(ratios, ratios[0], rtol=1.0e-12)
+
+
+def test_phitilde_mg_nrm_near_one() -> None:
+    """With the sqrt(Nf/2) prefactor the normalization constant is 1 to window accuracy."""
+    Nf, Nt, mult_f = 32, 64, 8
+    ND = Nf * Nt
+    phif = np.sqrt(Nf / 2) * np.asarray(mg.phihat_eval(np.arange(0, mult_f * Nt // 2 + 1) / Nt))
+    nrm = np.sqrt((2 * np.sum(phif[1:] ** 2) + phif[0] ** 2) * 2 * np.pi / ND) / np.sqrt(np.pi)
+    assert_allclose(nrm, 1.0, atol=1.0e-5)
+
+
+def test_om_dot_fft_matches_explicit() -> None:
+    """The fft-based Omega matrix product agrees with the explicit-loop implementation."""
+    M, N, nu = 6, 10, 0.5
+    rng = np.random.default_rng(909)
+    n_pair = (2 * M + 1) * (2 * N + 1)
+    b = rng.normal(size=n_pair) + 1j * rng.normal(size=n_pair)
+
+    kernel_even, _kernel_odd, _m_scales, _n_scales = mg._kernel_helper(M, N, nu)  # noqa: SLF001
+    fft_shape = (
+        mg._next_fast_even(2 * M + 1 + kernel_even.shape[0] - 1),  # noqa: SLF001
+        mg._next_fast_even(2 * N + 1 + kernel_even.shape[1] - 1),  # noqa: SLF001
+    )
+    F_even = fftn(kernel_even, fft_shape)
+    F_odd = np.roll(F_even, fft_shape[0] // 2, axis=0)
+
+    out_fft = mg._om_dot_helper(M, N, b, F_even, F_odd, fft_shape)  # noqa: SLF001
+    out_explicit = mg._om_dot_helper_explicit(M, N, b, kernel_even)  # noqa: SLF001
+    assert_allclose(out_fft, out_explicit, atol=1.0e-12 * np.max(np.abs(out_explicit)), rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# time-domain path and cross-domain consistency for the modified Gaussian
+# ---------------------------------------------------------------------------
+
+
+def test_time_domain_mg_roundtrip() -> None:
+    """The time-domain mg path (which crashed before the phi_vec signature fix) is
+    self-consistent to machine precision at large mult.
+    """
+    Nf, Nt = 16, 32
+    rng = np.random.default_rng(1010)
+    x = rng.normal(size=Nf * Nt)
+    w = transform_wavelet_time(x, Nf, Nt, mult=16, family='modified_gaussian')
+    x_rec = inverse_wavelet_time(w, Nf, Nt, mult=16, family='modified_gaussian')
+    # accuracy limited by the time tail of the orthogonalized window truncated at
+    # mult = Nt/2 pixels, not by machine precision
+    assert_allclose(x_rec, x, atol=1.0e-10 * np.max(np.abs(x)), rtol=0.0)
+
+
+def test_time_freq_domain_agreement_mg() -> None:
+    """Forward transforms computed in the time and frequency domains agree to the
+    frequency-window truncation error.
+    """
+    Nf, Nt = 16, 32
+    rng = np.random.default_rng(1111)
+    x = rng.normal(size=Nf * Nt)
+    w_time = transform_wavelet_time(x, Nf, Nt, mult=16, family='modified_gaussian')
+    w_freq = transform_wavelet_freq_time(x, Nf, Nt, mult_f=16, family='modified_gaussian')
+    assert_allclose(w_time, w_freq, atol=1.0e-9 * np.max(np.abs(w_freq)), rtol=0.0)
+    x_rec = inverse_wavelet_freq_time(w_freq, Nf, Nt, mult_f=16, family='modified_gaussian')
+    assert_allclose(x_rec, x, atol=1.0e-9 * np.max(np.abs(x)), rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# public API guards
+# ---------------------------------------------------------------------------
+
+
+def test_meyer_is_default_family() -> None:
+    """Backward compatibility: the default family is the original Meyer wavelet."""
+    Nf, Nt = 8, 16
+    rng = np.random.default_rng(1212)
+    data = _rand_rfft(Nf * Nt, rng)
+    w_default = transform_wavelet_freq(data, Nf, Nt)
+    w_meyer = transform_wavelet_freq(data, Nf, Nt, family='meyer')
+    assert np.array_equal(w_default, w_meyer)
+
+
+def test_unknown_family_raises() -> None:
+    Nf, Nt = 8, 16
+    data = np.zeros(Nf * Nt // 2 + 1, dtype=np.complex128)
+    with pytest.raises(ValueError, match='family'):
+        transform_wavelet_freq(data, Nf, Nt, family='haar')


### PR DESCRIPTION
## Summary

Fixes frequency-domain transform boundary conventions, the modified-Gaussian window grid, and the mg time-domain path. Adds a plain-numpy reference specification and a comprehensive convention test suite.

- **Frequency-domain boundaries (both directions):** windows crossing the frequency extremes are now handled exactly — forward uses conjugate fold-back for interior bands (instead of zero-truncation); inverse uses mirror-lobe fold-back with `2*Re` at self-conjugate bins `0` and `ND/2`, and drops the stray `m=Nf` tap the forward never produces. Resolved the center-tap conjugation TODO via the uniform `i_midpoint % Nt` index.
- **modified_gaussian window:** `phitilde_vec_norm` now sampled on the exact bin grid `arange(0, K/2+1)/Nt` (the old `endpoint=False` grid was misscaled and dominated round-trip error); prefactor corrected to `sqrt(Nf/2)`. Fixed `phi_vec` signature crash (`mult_t` kwarg / `nu` shadowing) that broke every time-domain mg call. Expansion coefficients computed lazily and cached.
- **Public API:** wavelet family selectable via `family='meyer'` (default, backward compatible) or `family='modified_gaussian'`; `mult_f` must satisfy `1 <= mult_f <= Nf`.
- **Performance:** both directions now use length-`Nt` ffts instead of length-`K`, ~`mult_f`× less fft work; jitted is 2.9–4.6× faster than the new numpy reference at Nf=2048, Nt=1024, mult_f=8.
- **Consolidation:** removed dead code (`DX_assign_loop_old`, `phi_vec_transform`, zak/frame-bound diagnostics, `_omega_array_loop`, `_om_dot_helper_old/_convolve`, commented-out inverse variants).

## New files
- `WDMWaveletTransforms/wavelet_reference.py` — plain-numpy executable spec of the conventions
- `tests/wavelet_convention_test.py` — 56 tests (jit==reference, closed-form atom cross-checks, round-trip convergence to 6e-15 at mult_f=24, boundary/edge cases, packing/normalization guards)
- `benchmark_transforms.py`

## Test plan
Modified-Gaussian round trip (Nf=32, Nt=64), previously stuck at ~1e-1 for all mult_f: now 1.7e-3 (mult_f=3), 2.6e-6 (8), 5.5e-12 (16), 6.1e-15 (24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)